### PR TITLE
Update network configuration when renaming a netdev

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.18
 
       - name: Check out
         uses: actions/checkout@v2

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -13,7 +13,7 @@ jobs:
       - name: Set up go
         uses: actions/setup-go@v2
         with:
-          go-version: 1.14
+          go-version: 1.18
 
       - name: Check out
         uses: actions/checkout@v2
@@ -47,7 +47,7 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }} 
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
           asset_path: "./linkctl-${{ steps.version.outputs.tag }}.tar.gz"
           asset_name: "linkctl-${{ steps.version.outputs.tag }}.tar.gz"
           asset_content_type: application/octet-stream

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,9 @@
 module github.com/haboustak/linkctl
 
-go 1.14
+go 1.18
 
 require (
+	github.com/smartystreets/goconvey v1.7.2 // indirect
 	golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae
 	gopkg.in/ini.v1 v1.57.0
 )

--- a/go.sum
+++ b/go.sum
@@ -1,4 +1,17 @@
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1 h1:EGx4pi6eqNxGaHF6qqu48+N2wcFQ5qg5FXgOdqsJ5d8=
+github.com/gopherjs/gopherjs v0.0.0-20181017120253-0766667cb4d1/go.mod h1:wJfORRmW1u3UXTncJ5qlYoELFm8eSnnEO6hX4iZ3EWY=
+github.com/jtolds/gls v4.20.0+incompatible h1:xdiiI2gbIgH/gLH7ADydsJ1uDOEzR8yvV7C0MuV77Wo=
+github.com/jtolds/gls v4.20.0+incompatible/go.mod h1:QJZ7F/aHp+rZTRtaJ1ow/lLfFfVYBRgL+9YlvaHOwJU=
+github.com/smartystreets/assertions v1.2.0 h1:42S6lae5dvLc7BrLu/0ugRtcFVjoJNMC/N3yZFZkDFs=
+github.com/smartystreets/assertions v1.2.0/go.mod h1:tcbTF8ujkAEcZ8TElKY+i30BzYlVhC/LOxJk7iOWnoo=
+github.com/smartystreets/goconvey v1.7.2 h1:9RBaZCeXEQ3UselpuwUQHltGVXvdwm6cv1hgR6gDIPg=
+github.com/smartystreets/goconvey v1.7.2/go.mod h1:Vw0tHAZW6lzCRk3xgdin6fKYcG+G3Pg9vgXWeJpQFMM=
+golang.org/x/crypto v0.0.0-20190308221718-c2843e01d9a2/go.mod h1:djNgcEr1/C05ACkg1iLfiJU5Ep61QUkGW8qpdssI0+w=
+golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
+golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae h1:Ih9Yo4hSPImZOpfGuA4bR/ORKTAbhZo2AbWNRCnevdo=
 golang.org/x/sys v0.0.0-20200625212154-ddb9806d33ae/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
+golang.org/x/tools v0.0.0-20190328211700-ab21143f2384/go.mod h1:LCzVGOaR6xXOjkQ3onu1FJEFr0SW1gC7cKk1uF8kGRs=
 gopkg.in/ini.v1 v1.57.0 h1:9unxIsFcTt4I55uWluz+UmL95q4kdJ0buvQ1ZIqVQww=
 gopkg.in/ini.v1 v1.57.0/go.mod h1:pNLf8WUiyNEtQjuu5G5vTm06TEv9tsIgeAvK8hOrP4k=

--- a/internal/networkd/network.go
+++ b/internal/networkd/network.go
@@ -58,17 +58,8 @@ func (self *Network) DropinForNetDev(netdev *NetDev) (*Unit, error) {
 			self.Interface.Name)
 	}
 
-	dropinPath := fmt.Sprintf(
-		"/etc/systemd/network/%s.d/%s.conf",
-		netdev.ParentNetwork.Unit.Name,
-		strings.TrimSuffix(netdev.Unit.Name, ".netdev"))
-
-	dropinUnit, err := NewUnit(dropinPath)
-	if err != nil {
-		return nil, err
-	}
-
-	return dropinUnit, nil
+	dropinName := strings.TrimSuffix(netdev.Unit.Name, ".netdev")
+	return self.Unit.NewDropin(dropinName)
 }
 
 func getNetworkUnit(intf *Interface) (*Unit, error) {

--- a/internal/networkd/unit.go
+++ b/internal/networkd/unit.go
@@ -1,9 +1,11 @@
 package networkd
 
 import (
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"gopkg.in/ini.v1"
 )
@@ -93,4 +95,143 @@ func NewUnit(path string) (*Unit, error) {
 	unit.File = iniFile
 
 	return &unit, nil
+}
+
+func (self *Unit) NewDropin(name string) (*Unit, error) {
+	dropinPath := fmt.Sprintf(
+		"/etc/systemd/network/%s.d/%s.conf",
+		self.Name,
+		name)
+
+	return NewUnit(dropinPath)
+}
+
+func (self *Unit) Dropins() []string {
+	dropinPath := fmt.Sprintf("/etc/systemd/network/%s.d/*.conf", self.Name)
+	dropins, err := filepath.Glob(dropinPath)
+	if err != nil {
+		panic(fmt.Errorf("Failed to list units at %s: %w", dropinPath, err))
+	}
+
+	return dropins
+}
+
+func (self *Unit) DropinUnits() chan *Unit {
+	r := make(chan *Unit, 5)
+
+	go func() {
+		for _, dropin := range self.Dropins() {
+			unit, err := NewUnit(dropin)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "WARN: Failed to parse networkd unit %s: %v\n", dropin, err)
+				continue
+			}
+			r <- unit
+		}
+		close(r)
+	}()
+
+	return r
+}
+
+func (self *Unit) ContainsValue(section string, key string, value string) bool {
+	for _, v := range self.GetValues(section, key) {
+		if v == value {
+			return true
+		}
+	}
+
+	return false
+}
+
+func (self *Unit) Set(section string, key string, value string) error {
+	if value == "" {
+		return self.Remove(section, key)
+	}
+
+	s := self.File.Section(section)
+	s.NewKey(key, value)
+	return self.Save()
+}
+
+func (self *Unit) Get(section string, key string) string {
+	s := self.File.Section(section)
+	if s == nil || !s.HasKey(key) {
+		return ""
+	}
+
+	return s.Key(key).String()
+}
+
+func (self *Unit) GetValues(section string, key string) []string {
+	if value := self.Get(section, key); value != "" {
+		return strings.Split(self.Get(section, key), " ")
+	}
+	return []string{}
+}
+
+func (self *Unit) SetValues(section string, key string, values []string) error {
+	return self.Set(section, key, strings.Join(values, " "))
+}
+
+func (self *Unit) Remove(section string, key string) error {
+	s := self.File.Section(section)
+	if s == nil {
+		return nil
+	}
+
+	s.DeleteKey(key)
+
+	// Delete the file if no more config exists
+	if self.IsEmpty() {
+		if err := self.Delete(); err != nil {
+			return err
+		}
+	} else if err := self.Save(); err != nil {
+		return err
+	}
+
+	return nil
+}
+
+func (self *Unit) Replace(section string, key string, old string, value string) error {
+	values := self.GetValues(section, key)
+	fmt.Printf("Setting value from %v\n", values)
+	update := make([]string, len(values)+1)
+	kept := 0
+	for _, v := range values {
+		if v != old && v != value {
+			update[kept] = v
+			kept += 1
+		}
+	}
+	fmt.Printf("Setting value after %v with |%s|\n", update, value)
+	update[kept] = value
+	fmt.Printf("Setting value to %v\n", update)
+	return self.SetValues(section, key, update)
+}
+
+func (self *Unit) Include(section string, key string, value string) error {
+	values := self.GetValues(section, key)
+	for _, v := range values {
+		if v == value {
+			return nil
+		}
+	}
+	values = append(values, value)
+	return self.SetValues(section, key, values)
+}
+
+func (self *Unit) Exclude(section string, key string, value string) error {
+	values := self.GetValues(section, key)
+	update := make([]string, len(values))
+	kept := 0
+	for _, v := range values {
+		if v != value {
+			update[kept] = v
+			kept += 1
+		}
+	}
+
+	return self.SetValues(section, key, update)
 }


### PR DESCRIPTION
A netdev may be using a custom network config, for example to set DHCP
options, and that network config may match the netdev by name. linkctl's
rename operation needs to detect this situation and ensure the
network is still applied after the link is renamed.